### PR TITLE
Fixed the missing optional tag on `Metrics` connection config parameter

### DIFF
--- a/prometheus/connection_config.go
+++ b/prometheus/connection_config.go
@@ -6,7 +6,7 @@ import (
 
 type prometheusConfig struct {
 	Address *string  `hcl:"address"`
-	Metrics []string `hcl:"metrics"`
+	Metrics []string `hcl:"metrics,optional"`
 }
 
 func ConfigInstance() interface{} {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
