### PR TITLE
Fixed the plugin initialization error by returning only the static tables if invalid config parameters were set for dynamic tables closes #38

### DIFF
--- a/prometheus/table_prometheus_dynamic_metric.go
+++ b/prometheus/table_prometheus_dynamic_metric.go
@@ -24,7 +24,7 @@ func tableDynamicMetric(ctx context.Context, p *plugin.TableMapData) *plugin.Tab
 	}
 
 	// Get the query for the metric (required)
-	metricName := ctx.Value("metric_name").(string)
+	metricName := ctx.Value(ctxKey("metric_name")).(string)
 	metricNameBytes, _ := json.Marshal(metricName)
 	q := fmt.Sprintf(`{__name__=%s}`, string(metricNameBytes))
 

--- a/prometheus/utils.go
+++ b/prometheus/utils.go
@@ -43,17 +43,19 @@ func connectRaw(ctx context.Context, cc *connection.ConnectionCache, c *plugin.C
 		Address: address,
 	})
 
-	conn := v1.NewAPI(client)
-
 	if err != nil {
-		return conn, err
+		plugin.Logger(ctx).Error("connectRaw", "client connection error", err)
+		return nil, err
 	}
+
+	conn := v1.NewAPI(client)
 
 	// Save to cache
 	err = cc.Set(ctx, cacheKey, conn)
 
 	if err != nil {
 		plugin.Logger(ctx).Error("connectRaw", "cache-set", err)
+		return conn, err
 	}
 
 	return conn, nil


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
