### PR TITLE
Implemented optional basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Configure the server address in `~/.steampipe/config/prometheus.spc`:
 connection "prometheus" {
   plugin  = "prometheus"
   address = "http://localhost:9090"
+  username = "optional_username"
+  password = "optional_password"
 }
 ```
 

--- a/prometheus/connection_config.go
+++ b/prometheus/connection_config.go
@@ -5,8 +5,10 @@ import (
 )
 
 type prometheusConfig struct {
-	Address *string  `hcl:"address"`
-	Metrics []string `hcl:"metrics,optional"`
+	Address  *string  `hcl:"address"`
+	Username *string  `hcl:"username,optional"`
+	Password *string  `hcl:"password,optional"`
+	Metrics  []string `hcl:"metrics,optional"`
 }
 
 func ConfigInstance() interface{} {

--- a/prometheus/utils.go
+++ b/prometheus/utils.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"context"
+	"net/http"
 	"os"
 
 	"github.com/prometheus/client_golang/api"
@@ -11,6 +12,18 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
 
+// roundTripperWithBasicAuth is a custom RoundTripper that includes basic authentication headers
+type roundTripperWithBasicAuth struct {
+	http.RoundTripper
+	username string
+	password string
+}
+
+func (rt *roundTripperWithBasicAuth) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(rt.username, rt.password)
+	return rt.RoundTripper.RoundTrip(req)
+}
+
 func connect(ctx context.Context, d *plugin.QueryData) (v1.API, error) {
 	return connectRaw(ctx, d.ConnectionCache, d.Connection)
 }
@@ -18,6 +31,8 @@ func connect(ctx context.Context, d *plugin.QueryData) (v1.API, error) {
 func connectRaw(ctx context.Context, cc *connection.ConnectionCache, c *plugin.Connection) (v1.API, error) {
 
 	var address string
+	username := ""
+	password := ""
 
 	// Load connection from cache, which preserves throttling protection etc
 	cacheKey := "prometheus"
@@ -33,14 +48,30 @@ func connectRaw(ctx context.Context, cc *connection.ConnectionCache, c *plugin.C
 		address = *prometheusConfig.Address
 	}
 
+	if prometheusConfig.Username != nil {
+		username = *prometheusConfig.Username
+	}
+	if prometheusConfig.Password != nil {
+		password = *prometheusConfig.Password
+	}
+
 	// Error if the minimum config is not set
 	if address == "" {
 		// Panic since we cannot create a valid empty API to return
 		panic("address must be configured")
 	}
 
+	//handle authentication
+	rt := api.DefaultRoundTripper
+	rt = &roundTripperWithBasicAuth{
+		RoundTripper: rt,
+		username:     username,
+		password:     password,
+	}
+
 	client, err := api.NewClient(api.Config{
-		Address: address,
+		Address:      address,
+		RoundTripper: rt,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Hi,
I've implemented optional authentication to Prometheus via 2 new config parameters, which may be commented-out: username and password.

It has been tested OK with both an anonymous Prometheus and an authenticating Prometheus (which we require and that's why I've added this features).

I hope it's good enough to be accepted.
This is actually my first attempt at developing in Go :)
